### PR TITLE
Update prop switch text variant

### DIFF
--- a/src/components/SandboxBlock/SandboxBlock.tsx
+++ b/src/components/SandboxBlock/SandboxBlock.tsx
@@ -86,7 +86,7 @@ const SandboxBlock: React.FC<SandboxBlockTypes> = ({libId, componentId, sandboxC
                         <Row key={prop} space="0">
                             <div className={b('prop')}>
                                 <div className={b('prop-switch')}>
-                                    <Text variant="body-2">{prop}</Text>
+                                    <Text variant="body-1">{prop}</Text>
                                     <Switch
                                         key={prop}
                                         title={prop}


### PR DESCRIPTION
This pull request updates the text variant of the prop switch in the SandboxBlock component. The previous variant was "body-2" and it has been changed to "body-1". This change ensures consistency with the design system and improves the readability of the prop switch. (Copilot)

https://github.com/gravity-ui/landing/issues/139

![image](https://github.com/gravity-ui/landing/assets/75197368/7c4c8448-75e3-4734-aa10-7f9b3afdb278)
