### PR TITLE
fix: hide component user-label in sandbox

### DIFF
--- a/src/content/components/uikit/UserLabel/index.ts
+++ b/src/content/components/uikit/UserLabel/index.ts
@@ -9,6 +9,7 @@ export const userLabelConfig = {
     id: 'user-label',
     title: 'UserLabel',
     githubUrl: getGithubUrl(getterOptions),
+    isComingSoon: true,
     content: {
         readmeUrl: getReadmeUrl(getterOptions),
     },


### PR DESCRIPTION
We should hide UserLabel because its readme in uikit6 has wrongs...