### PR TITLE
fix: incorrect border radius variables documentation

### DIFF
--- a/src/content/design/guides/content/CornerRadius.mdx
+++ b/src/content/design/guides/content/CornerRadius.mdx
@@ -1,11 +1,11 @@
 The corner radius of controls can be overridden. To do this, use the following variables:
 
-- -g-border-radius-xs: 3px;
-- -g-border-radius-s: 5px;
-- -g-border-radius-m: 6px;
-- -g-border-radius-l: 8px;
-- -g-border-radius-xl: 10px;
-- -g-border-radius-2xl: 16px;
+- --g-border-radius-xs: 3px;
+- --g-border-radius-s: 5px;
+- --g-border-radius-m: 6px;
+- --g-border-radius-l: 8px;
+- --g-border-radius-xl: 10px;
+- --g-border-radius-2xl: 16px;
 
 ![Corner radius](/static/images/design/CornerRadius/1.png)
 


### PR DESCRIPTION
Before
<img width="382" alt="Screenshot 2024-08-09 at 17 47 44" src="https://github.com/user-attachments/assets/ad384e2c-a160-4e9d-b864-51dfead86c29">

After 
<img width="343" alt="Screenshot 2024-08-09 at 17 47 48" src="https://github.com/user-attachments/assets/b5900f82-1aa6-4b67-88b6-d4986f59554e">