### PR TITLE
feat: add google site console verification tag

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -18,6 +18,10 @@ class CustomDocument extends Document {
             // Workaround for missing direction 'ltr' in ThemeProvider
             <Html lang={currentLocale} dir="ltr">
                 <Head>
+                    <meta
+                        name="google-site-verification"
+                        content="QhqdVzck0x0Hw82h7fl_l9ebRsYpSqlC_JhyDRXBnew"
+                    />
                     {IS_PRODUCTION && (
                         <Script
                             id="google-analytics"


### PR DESCRIPTION
Add meta tag to get an access to google site console. We need this access to check the SEO performance of our site in google search.