### PR TITLE
fix: contributors list text avatar height

### DIFF
--- a/src/components/BaseContributorList/BaseContributorList.scss
+++ b/src/components/BaseContributorList/BaseContributorList.scss
@@ -6,21 +6,21 @@
 $block: '.#{variables.$ns}base-contributor-list';
 
 #{$block} {
-    position: relative;
-    overflow: hidden;
     display: grid;
     gap: 11px;
     grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
 
     &__link {
-        display: inline-block;
-        padding: 0;
+        position: relative;
+        padding: 100% 0 0;
         margin: 0;
     }
 
     &__avatar {
-        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
         width: 100%;
-        height: auto;
+        height: 100%;
     }
 }


### PR DESCRIPTION
This PR fixes the inconsistent height of the TextAvatar component in the Contribution list, ensuring proper alignment with other elements.

**Before:**
<img width="467" height="425" alt="image" src="https://github.com/user-attachments/assets/6909f2d3-3544-4b87-a1dc-c8106aadc84e" />

**After:**
<img width="506" height="438" alt="image" src="https://github.com/user-attachments/assets/58b2dac9-7f6f-4189-86ff-08d018018985" />
