### PR TITLE
fix: revert contributors list relative styles

### DIFF
--- a/src/components/BaseContributorList/BaseContributorList.scss
+++ b/src/components/BaseContributorList/BaseContributorList.scss
@@ -6,6 +6,8 @@
 $block: '.#{variables.$ns}base-contributor-list';
 
 #{$block} {
+    position: relative;
+    overflow: hidden;
     display: grid;
     gap: 11px;
     grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));


### PR DESCRIPTION
<img width="1361" height="551" alt="image" src="https://github.com/user-attachments/assets/9a83919e-c2da-4cb5-8d87-7b67f38927fa" />
<img width="501" height="179" alt="image" src="https://github.com/user-attachments/assets/0a690506-71e4-4a9a-8f87-a1aef2fcce63" />
