### PR TITLE
feat: changed markdown article in en to medium

### DIFF
--- a/src/content/media-en.yaml
+++ b/src/content/media-en.yaml
@@ -1,5 +1,5 @@
 background:
-  image: ""
+  image: ''
 blocks:
   - type: header-block
     title: Our Media
@@ -9,46 +9,51 @@ blocks:
     list:
       - text: Playwright and PerformanceObserver API were used;
         icon: https://storage.yandexcloud.net/gravity-landing-static/assets/icon_1_dark.svg
-      - text: tests were repeated 50 times with different number of nodes (10, 100, 1000).      
+      - text: tests were repeated 50 times with different number of nodes (10, 100, 1000).
         icon: https://storage.yandexcloud.net/gravity-landing-static/assets/icon_1_dark.svg
     media:
       image: >-
-        https://storage.yandexcloud.net/gravity-landing-static/assets/is_it_slow.png 
+        https://storage.yandexcloud.net/gravity-landing-static/assets/is_it_slow.png
     button:
       text: Read the post
       url: >-
         https://habr.com/ru/companies/yandex/posts/931702/
+      target: _blank
       theme: accent
   - type: slider-block
     dots: true
     title: Articles
     autoplay: 5000
-    children:  
+    children:
       - type: basic-card
-        title: "Gravity UI Design System: How to Easily Build Your Interface"
+        title: 'Gravity UI Design System: How to Easily Build Your Interface'
         text: >-
           A story about why we created Gravity UI, how we use it, what are
           the features and advantages of our approach and how we plan to develop
           it further.
         url: https://medium.com/p/32985f939f1c
+        target: _blank
       - type: basic-card
-        title: "Graph Visualization Library: How We Solved the Canvas vs HTML Dilemma in Gravity UI"
+        title: 'Graph Visualization Library: How We Solved the Canvas vs HTML Dilemma in Gravity UI'
         text: >-
           A post about the architectural challenges that arose during the creation of the
           Gravity UI Graph library, which reveals how the current implementation of the library was formed.
-        url: https://habr.com/ru/companies/yandex/articles/934562/   
+        url: https://habr.com/ru/companies/yandex/articles/934562/
+        target: _blank
       - type: basic-card
         title: How We Made Yandex Cloud More Accessible with Gravity UI Design System
         text: How to build an accessible interface using GravityUI libraries.
         url: https://habr.com/en/companies/yandex_cloud_and_infra/articles/853382/
+        target: _blank
       - type: basic-card
-        title: "Markdown Editor: WYSIWYG and Markup Editor Based on Gravity UI"
+        title: 'Markdown Editor: WYSIWYG and Markup Editor Based on Gravity UI'
         text: >-
           Let's talk about the history of user interface creation,
           architectural features and technical details of integration and
           development of custom extensions, and then - why all this is available in
           open source.
-        url: https://habr.com/en/companies/yandex/articles/845802/
+        url: https://medium.com/yandex/markdown-editor-wysiwyg-and-markup-editor-based-on-gravity-ui-43e97183ac8d
+        target: _blank
   - type: filter-block
     title: Webinars
     description: >
@@ -63,24 +68,24 @@ blocks:
           - youtube
         card:
           type: layout-item
-          media:     
-            youtube: "https://www.youtube.com/watch?v=9J3tuiLq6rA"
-            previewImg: "https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png"            
+          media:
+            youtube: 'https://www.youtube.com/watch?v=9J3tuiLq6rA'
+            previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png'
           border: true
-          fullscreen: false   
+          fullscreen: true
           content:
-            title: "Navigation"
+            title: 'Navigation'
             text: >-
               Introductory webinar on Navigation library
       - tags:
           - youtube
         card:
           type: layout-item
-          media:           
-            youtube: "https://www.youtube.com/watch?v=e77kbTjqZX8"
-            previewImg: "https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png"
+          media:
+            youtube: 'https://www.youtube.com/watch?v=e77kbTjqZX8'
+            previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png'
           border: true
-          fullscreen: false   
+          fullscreen: true
           content:
             title: Introductory webinar
             text: >-
@@ -92,9 +97,9 @@ blocks:
             videoIframe: 'https://runtime.strm.yandex.ru/player/video/vplvibavcepgpr3wkjew'
             previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png'
           border: true
-          fullscreen: false 
+          fullscreen: true
           content:
-            title: "Navigation"
+            title: 'Navigation'
             text: >-
               Introductory webinar on Navigation library
       - tags:
@@ -105,7 +110,7 @@ blocks:
             videoIframe: 'https://runtime.strm.yandex.ru/player/episode/vpleycdol66bubppvqg7'
             previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
             title: Introductory webinar
     allTag: false
@@ -113,10 +118,10 @@ blocks:
     textWidth: s
     centered: true
     background:
-      src: ""
+      src: ''
       style:
-        backgroundColor: "#23151E"
-        color: ""
+        backgroundColor: '#23151E'
+        color: ''
     textContent:
       title: Have questions?
       #text: Write to us

--- a/src/content/media-es.yaml
+++ b/src/content/media-es.yaml
@@ -1,5 +1,5 @@
 background:
-  image: ""
+  image: ''
 blocks:
   - type: header-block
     title: Nuestros Medios
@@ -9,46 +9,51 @@ blocks:
     list:
       - text: se utilizaron Playwright y PerformanceObserver API;
         icon: https://storage.yandexcloud.net/gravity-landing-static/assets/icon_1_dark.svg
-      - text: las pruebas se repitieron 50 veces con diferentes números de nodos (10, 100, 1000).      
+      - text: las pruebas se repitieron 50 veces con diferentes números de nodos (10, 100, 1000).
         icon: https://storage.yandexcloud.net/gravity-landing-static/assets/icon_1_dark.svg
     media:
       image: >-
-        https://storage.yandexcloud.net/gravity-landing-static/assets/is_it_slow.png 
+        https://storage.yandexcloud.net/gravity-landing-static/assets/is_it_slow.png
     button:
       text: Leer la publicación
       url: >-
         https://habr.com/ru/companies/yandex/posts/931702/
+      target: _blank
       theme: accent
   - type: slider-block
     dots: true
     title: Artículos
     autoplay: 5000
-    children:  
+    children:
       - type: basic-card
-        title: "Sistema de diseño Gravity UI: cómo construir fácilmente tu interfaz"
+        title: 'Sistema de diseño Gravity UI: cómo construir fácilmente tu interfaz'
         text: >-
           Una historia sobre por qué creamos Gravity UI, cómo lo usamos, cuáles son
           las características y ventajas de nuestro enfoque y cómo planeamos desarrollarlo
           en el futuro.
         url: https://medium.com/p/32985f939f1c
+        target: _blank
       - type: basic-card
-        title: "Biblioteca de visualización de grafos: cómo resolvimos el dilema Canvas vs HTML en Gravity UI"
+        title: 'Biblioteca de visualización de grafos: cómo resolvimos el dilema Canvas vs HTML en Gravity UI'
         text: >-
           Una publicación sobre los desafíos arquitectónicos que surgieron durante la creación de la
           biblioteca Gravity UI Graph, que revela cómo se formó la implementación actual de la biblioteca.
-        url: https://habr.com/ru/companies/yandex/articles/934562/   
+        url: https://habr.com/ru/companies/yandex/articles/934562/
+        target: _blank
       - type: basic-card
         title: Cómo hicimos Yandex Cloud más accesible con el sistema de diseño Gravity UI
         text: Cómo construir una interfaz accesible utilizando las bibliotecas GravityUI.
         url: https://habr.com/en/companies/yandex_cloud_and_infra/articles/853382/
+        target: _blank
       - type: basic-card
-        title: "Markdown Editor: Editor WYSIWYG y de markup basado en Gravity UI"
+        title: 'Markdown Editor: Editor WYSIWYG y de markup basado en Gravity UI'
         text: >-
           Hablemos sobre la historia de la creación de la interfaz de usuario,
           las características arquitectónicas y los detalles técnicos de la integración y
           desarrollo de extensiones personalizadas, y luego, por qué todo esto está disponible en
           código abierto.
-        url: https://habr.com/en/companies/yandex/articles/845802/
+        url: https://medium.com/yandex/markdown-editor-wysiwyg-and-markup-editor-based-on-gravity-ui-43e97183ac8d
+        target: _blank
   - type: filter-block
     title: Webinars
     description: >
@@ -63,24 +68,24 @@ blocks:
           - youtube
         card:
           type: layout-item
-          media:     
-            youtube: "https://www.youtube.com/watch?v=9J3tuiLq6rA"
-            previewImg: "https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png"            
+          media:
+            youtube: 'https://www.youtube.com/watch?v=9J3tuiLq6rA'
+            previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png'
           border: true
-          fullscreen: false  
+          fullscreen: true
           content:
-            title: "Navigation"
+            title: 'Navigation'
             text: >-
               Webinar introductorio sobre la biblioteca Navigation
       - tags:
           - youtube
         card:
           type: layout-item
-          media:           
-            youtube: "https://www.youtube.com/watch?v=e77kbTjqZX8"
-            previewImg: "https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png"
+          media:
+            youtube: 'https://www.youtube.com/watch?v=e77kbTjqZX8'
+            previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
             title: Webinar introductorio
             text: >-
@@ -92,9 +97,9 @@ blocks:
             videoIframe: 'https://runtime.strm.yandex.ru/player/video/vplvibavcepgpr3wkjew'
             previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
-            title: "Navigation"
+            title: 'Navigation'
             text: >-
               Webinar introductorio sobre la biblioteca Navigation
       - tags:
@@ -105,7 +110,7 @@ blocks:
             videoIframe: 'https://runtime.strm.yandex.ru/player/episode/vpleycdol66bubppvqg7'
             previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
             title: Webinar introductorio
     allTag: false
@@ -113,10 +118,10 @@ blocks:
     textWidth: s
     centered: true
     background:
-      src: ""
+      src: ''
       style:
-        backgroundColor: "#23151E"
-        color: ""
+        backgroundColor: '#23151E'
+        color: ''
     textContent:
       title: ¿Tienes preguntas?
       #text: Escríbenos

--- a/src/content/media-ru.yaml
+++ b/src/content/media-ru.yaml
@@ -1,5 +1,5 @@
 background:
-  image: ""
+  image: ''
 blocks:
   - type: header-block
     title: Наши медиа
@@ -9,46 +9,51 @@ blocks:
     list:
       - text: использовались Playwright и PerformanceObserver API;
         icon: https://storage.yandexcloud.net/gravity-landing-static/assets/icon_1_dark.svg
-      - text: тесты повторялись 50 раз с разным количеством нод (10, 100, 1000).      
+      - text: тесты повторялись 50 раз с разным количеством нод (10, 100, 1000).
         icon: https://storage.yandexcloud.net/gravity-landing-static/assets/icon_1_dark.svg
     media:
       image: >-
-        https://storage.yandexcloud.net/gravity-landing-static/assets/is_it_slow.png 
+        https://storage.yandexcloud.net/gravity-landing-static/assets/is_it_slow.png
     button:
       text: Прочитать пост
       url: >-
         https://habr.com/ru/companies/yandex/posts/931702/
+      target: _blank
       theme: accent
   - type: slider-block
     dots: true
     title: Статьи
     autoplay: 5000
-    children:  
+    children:
       - type: basic-card
-        title: "Дизайн-система Gravity UI: как легко построить свой интерфейс"
+        title: 'Дизайн-система Gravity UI: как легко построить свой интерфейс'
         text: >-
           Рассказ, зачем мы сделали Gravity UI, как его используем, в чём
           особенности и преимущества нашего подхода и как мы планируем развивать
           его дальше.
         url: https://habr.com/en/companies/yandex/articles/773870/
+        target: _blank
       - type: basic-card
-        title: "Библиотека визуализации графов: как мы решили дилемму Canvas vs HTML в Gravity UI"
+        title: 'Библиотека визуализации графов: как мы решили дилемму Canvas vs HTML в Gravity UI'
         text: >-
           Пост про архитектурные вызовы, которые возникали при создании библиотеки 
           Gravity UI Graph, в нём раскрыто, как формировалась текущая реализации библиотеки.
-        url: https://habr.com/ru/companies/yandex/articles/934562/ 
+        url: https://habr.com/ru/companies/yandex/articles/934562/
+        target: _blank
       - type: basic-card
         title: Как мы делали Yandex Cloud на дизайн-системе Gravity UI доступнее
         text: Как построить доступный интерефейс, используя библиотеки GravityUI.
         url: https://habr.com/en/companies/yandex_cloud_and_infra/articles/853382/
+        target: _blank
       - type: basic-card
-        title: "Markdown Editor: WYSIWYG и markup-редактор на базе Gravity UI"
+        title: 'Markdown Editor: WYSIWYG и markup-редактор на базе Gravity UI'
         text: >-
           Поговорим об истории создания пользовательского интерфейса,
           архитектурных особенностях и технических деталях интеграции и
           разработки собственных расширений, а потом — почему всё это доступно в
           опенсорсе.
         url: https://habr.com/en/companies/yandex/articles/845802/
+        target: _blank
   - type: filter-block
     title: Вебинары
     description: >
@@ -57,30 +62,30 @@ blocks:
       - id: cloudvideo
         label: Cloud Video
       - id: youtube
-        label: YouTube    
+        label: YouTube
     items:
       - tags:
           - youtube
         card:
           type: layout-item
-          media:     
-            youtube: "https://www.youtube.com/watch?v=9J3tuiLq6rA"
-            previewImg: "https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png"            
+          media:
+            youtube: 'https://www.youtube.com/watch?v=9J3tuiLq6rA'
+            previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
-            title: "Navigation"
+            title: 'Navigation'
             text: >-
               Вводный вебинар по библиотеке Navigation
       - tags:
           - youtube
         card:
           type: layout-item
-          media:           
-            youtube: "https://www.youtube.com/watch?v=e77kbTjqZX8"
-            previewImg: "https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png"
+          media:
+            youtube: 'https://www.youtube.com/watch?v=e77kbTjqZX8'
+            previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
             title: Вводный вебинар
             text: >-
@@ -92,9 +97,9 @@ blocks:
             videoIframe: 'https://runtime.strm.yandex.ru/player/video/vplvibavcepgpr3wkjew'
             previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
-            title: "Navigation"
+            title: 'Navigation'
             text: >-
               Вводный вебинар по библиотеке Navigation
       - tags:
@@ -105,7 +110,7 @@ blocks:
             videoIframe: 'https://runtime.strm.yandex.ru/player/episode/vpleycdol66bubppvqg7'
             previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
             title: Вводный вебинар
     allTag: false
@@ -113,10 +118,10 @@ blocks:
     textWidth: s
     centered: true
     background:
-      src: ""
+      src: ''
       style:
-        backgroundColor: "#23151E"
-        color: ""
+        backgroundColor: '#23151E'
+        color: ''
     textContent:
       title: Остались вопросы?
       #text: Напишите нам

--- a/src/content/media-zh.yaml
+++ b/src/content/media-zh.yaml
@@ -1,5 +1,5 @@
 background:
-  image: ""
+  image: ''
 blocks:
   - type: header-block
     title: 我们的媒体
@@ -9,44 +9,49 @@ blocks:
     list:
       - text: 使用了Playwright和PerformanceObserver API；
         icon: https://storage.yandexcloud.net/gravity-landing-static/assets/icon_1_dark.svg
-      - text: 测试重复进行了50次，使用不同数量的节点（10、100、1000）。      
+      - text: 测试重复进行了50次，使用不同数量的节点（10、100、1000）。
         icon: https://storage.yandexcloud.net/gravity-landing-static/assets/icon_1_dark.svg
     media:
       image: >-
-        https://storage.yandexcloud.net/gravity-landing-static/assets/is_it_slow.png 
+        https://storage.yandexcloud.net/gravity-landing-static/assets/is_it_slow.png
     button:
       text: 阅读文章
       url: >-
         https://habr.com/ru/companies/yandex/posts/931702/
+      target: _blank
       theme: accent
   - type: slider-block
     dots: true
     title: 文章
     autoplay: 5000
-    children:  
+    children:
       - type: basic-card
-        title: "Gravity UI设计系统：如何轻松构建您的界面"
+        title: 'Gravity UI设计系统：如何轻松构建您的界面'
         text: >-
           关于我们为什么创建Gravity UI、如何使用它、我们方法的特点和优势
           以及我们计划如何进一步发展它的故事。
         url: https://medium.com/p/32985f939f1c
+        target: _blank
       - type: basic-card
-        title: "图形可视化库：我们如何在Gravity UI中解决Canvas vs HTML的难题"
+        title: '图形可视化库：我们如何在Gravity UI中解决Canvas vs HTML的难题'
         text: >-
           一篇关于在创建Gravity UI Graph库过程中出现的架构挑战的文章，
           其中揭示了库的当前实现是如何形成的。
-        url: https://habr.com/ru/companies/yandex/articles/934562/   
+        url: https://habr.com/ru/companies/yandex/articles/934562/
+        target: _blank
       - type: basic-card
         title: 我们如何使用Gravity UI设计系统让Yandex Cloud更易用
         text: 如何使用GravityUI库构建可访问的界面。
         url: https://habr.com/en/companies/yandex_cloud_and_infra/articles/853382/
+        target: _blank
       - type: basic-card
-        title: "Markdown编辑器：基于Gravity UI的WYSIWYG和标记编辑器"
+        title: 'Markdown编辑器：基于Gravity UI的WYSIWYG和标记编辑器'
         text: >-
           让我们谈论用户界面创建的历史、架构特性和集成的技术细节
           以及自定义扩展的开发，然后 - 为什么所有这些都可以在
           开源中使用。
-        url: https://habr.com/en/companies/yandex/articles/845802/
+        url: https://medium.com/yandex/markdown-editor-wysiwyg-and-markup-editor-based-on-gravity-ui-43e97183ac8d
+        target: _blank
   - type: filter-block
     title: 网络研讨会
     description: >
@@ -61,24 +66,24 @@ blocks:
           - youtube
         card:
           type: layout-item
-          media:     
-            youtube: "https://www.youtube.com/watch?v=9J3tuiLq6rA"
-            previewImg: "https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png"            
+          media:
+            youtube: 'https://www.youtube.com/watch?v=9J3tuiLq6rA'
+            previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png'
           border: true
-          fullscreen: false   
+          fullscreen: true
           content:
-            title: "Navigation"
+            title: 'Navigation'
             text: >-
               Navigation库介绍网络研讨会
       - tags:
           - youtube
         card:
           type: layout-item
-          media:           
-            youtube: "https://www.youtube.com/watch?v=e77kbTjqZX8"
-            previewImg: "https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png"
+          media:
+            youtube: 'https://www.youtube.com/watch?v=e77kbTjqZX8'
+            previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png'
           border: true
-          fullscreen: false 
+          fullscreen: true
           content:
             title: 介绍网络研讨会
             text: >-
@@ -90,9 +95,9 @@ blocks:
             videoIframe: 'https://runtime.strm.yandex.ru/player/video/vplvibavcepgpr3wkjew'
             previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/w_Navigation-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
-            title: "Navigation"
+            title: 'Navigation'
             text: >-
               Navigation库介绍网络研讨会
       - tags:
@@ -103,7 +108,7 @@ blocks:
             videoIframe: 'https://runtime.strm.yandex.ru/player/episode/vpleycdol66bubppvqg7'
             previewImg: 'https://storage.yandexcloud.net/gravity-landing-static/assets/zastavka-2.png'
           border: true
-          fullscreen: false
+          fullscreen: true
           content:
             title: 介绍网络研讨会
     allTag: false
@@ -111,10 +116,10 @@ blocks:
     textWidth: s
     centered: true
     background:
-      src: ""
+      src: ''
       style:
-        backgroundColor: "#23151E"
-        color: ""
+        backgroundColor: '#23151E'
+        color: ''
     textContent:
       title: 有问题吗？
       #text: 联系我们


### PR DESCRIPTION
1. Changed MD editor article link from habr to medium for en, es, zh locales.
2. Added target: _blank option to urls in yaml. Now links will be opened in a new tabs.
3. Added fullscreen: true prop to videos. (Recently we changed it to false, because during the testing we thought that there is a bug with video when fullscreen set to true. I asked page-constructor team and they reassured me, that this option works just fine if it can detect a mobile device.)