### PR TITLE
fix: delete static canonical

### DIFF
--- a/src/components/Layout/Meta/Meta.tsx
+++ b/src/components/Layout/Meta/Meta.tsx
@@ -32,8 +32,6 @@ export const Meta: React.FC<MetaProps> = ({
 
             <meta name="description" content={description} />
 
-            <link data-react-helmet="true" rel="canonical" href="https://gravity-ui.com/" />
-
             <meta itemProp="name" content={name} />
             <meta itemProp="description" content={description} />
             <meta itemProp="image" content={image} />


### PR DESCRIPTION
We have dynamic canonical link generation in _document.tsx file, it works well. The second static canonical is an error.