### PR TITLE
fix: icons search api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/src/content/local-docs ./src/content/local-docs
 COPY --from=builder /app/public ./public
 
-RUN apk add --no-cache curl bash
+RUN apk add --no-cache curl bash gcompat
 
 RUN addgroup -g 1001 app && \
     adduser -u 1001 -G app -S appuser && \


### PR DESCRIPTION
Fix error

```
 ⨯ Error: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /app/node_modules/onnxruntime-node/bin/napi-v3/linux/x64//libonnxruntime.so.1)
```