### PR TITLE
Fix anchoring to the sections written in non-english characters

### DIFF
--- a/src/components/MDXRenderer/MDXRenderer.tsx
+++ b/src/components/MDXRenderer/MDXRenderer.tsx
@@ -89,14 +89,18 @@ export const MDXRenderer = React.memo<Props>(
         React.useEffect(() => {
             if (isMounted) {
                 const content = document.getElementById(CONTENT_WRAPPER_ID);
-                const sectionId = window.location.hash.split('#')[1];
-                const section = document.querySelector<HTMLElement>('#' + sectionId);
+                try {
+                    const sectionId = decodeURI(window.location.hash).split('#')[1];
+                    const section = document.querySelector<HTMLElement>('#' + sectionId);
 
-                if (content && section) {
-                    content.scrollTo({
-                        top: section.offsetTop,
-                        behavior: 'smooth',
-                    });
+                    if (content && section) {
+                        content.scrollTo({
+                            top: section.offsetTop,
+                            behavior: 'smooth',
+                        });
+                    }
+                } catch (err) {
+                    console.error(err);
                 }
             }
         }, [isMounted]);


### PR DESCRIPTION
Currently when you open link to the component with non-english characters application crashes because it cannot decode percent-encoded charters.

I added decodeURI to fix anchoring issue and try catch to quietly ignore parsing errors instead of crashing application