### PR TITLE
chore: bump @gravity-ui/uikit to 7.39.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@gravity-ui/navigation": "^4.0.15",
         "@gravity-ui/page-constructor": "^8.0.0",
         "@gravity-ui/timeline": "^1.26.1",
-        "@gravity-ui/uikit": "^7.38.0",
+        "@gravity-ui/uikit": "^7.39.0",
         "@gravity-ui/uikit-themer": "^1.7.0",
         "@huggingface/transformers": "^3.8.1",
         "@mdx-js/mdx": "^2.3.0",
@@ -4056,9 +4056,9 @@
       "dev": true
     },
     "node_modules/@gravity-ui/uikit": {
-      "version": "7.38.0",
-      "resolved": "https://registry.npmjs.org/@gravity-ui/uikit/-/uikit-7.38.0.tgz",
-      "integrity": "sha512-heMWQgJKhz/a9WZTJdUeoI9lV30jtRQbaZisPBMJyFw8+IB1S/mCeMdp83B8HLaxydLFxz/2jt4NqOj2Hy67zQ==",
+      "version": "7.39.0",
+      "resolved": "https://registry.npmjs.org/@gravity-ui/uikit/-/uikit-7.39.0.tgz",
+      "integrity": "sha512-mMFoxvdA5L4/P7oIw9hYF/GMBvCWc9V0u0NWLj600tJ/tV+MDYUgjTdi3U1YRzjK79Antr+4r+rvBt9cgxwnpQ==",
       "license": "MIT",
       "dependencies": {
         "@bem-react/classname": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@gravity-ui/navigation": "^4.0.15",
     "@gravity-ui/page-constructor": "^8.0.0",
     "@gravity-ui/timeline": "^1.26.1",
-    "@gravity-ui/uikit": "^7.38.0",
+    "@gravity-ui/uikit": "^7.39.0",
     "@gravity-ui/uikit-themer": "^1.7.0",
     "@huggingface/transformers": "^3.8.1",
     "@mdx-js/mdx": "^2.3.0",


### PR DESCRIPTION
After this PR is merged, the sandbox will pull the updated documentation from the new uikit version.
https://github.com/gravity-ui/uikit/pull/2663