### PR TITLE
fix: fix og meta images

### DIFF
--- a/scripts/update-og-images.mjs
+++ b/scripts/update-og-images.mjs
@@ -29,7 +29,7 @@ try {
         await page.goto(`https://gravity-ui.com/libraries/${id}/preview`, {
             waitUntil: 'networkidle',
         });
-        const buffer = await page.screenshot();
+        const buffer = await page.screenshot({type: 'jpeg', quality: 90});
 
         const uploadParams = {
             Bucket: BUCKET_NAME,

--- a/src/components/Layout/Meta/Meta.tsx
+++ b/src/components/Layout/Meta/Meta.tsx
@@ -6,18 +6,27 @@ const DEFAULT_META = {
     name: SITE_NAME,
     description: 'Build modern interfaces with the Gravity design system and libraries',
     image: 'https://gravity-ui.com/index-social.png',
+    imageType: 'image/png',
+    imageWidth: 1280,
+    imageHeight: 640,
 };
 
 export type MetaProps = {
     name?: string;
     description?: string;
     image?: string;
+    imageType?: string;
+    imageWidth?: number;
+    imageHeight?: number;
 };
 
 export const Meta: React.FC<MetaProps> = ({
     name = DEFAULT_META.name,
     description = DEFAULT_META.description,
     image = DEFAULT_META.image,
+    imageType = DEFAULT_META.imageType,
+    imageWidth = DEFAULT_META.imageWidth,
+    imageHeight = DEFAULT_META.imageHeight,
 }) => {
     return (
         <React.Fragment>
@@ -43,6 +52,11 @@ export const Meta: React.FC<MetaProps> = ({
             <meta property="og:type" content="website" />
             <meta property="og:site_name" content={SITE_NAME} />
             <meta property="og:image" content={image} />
+            <meta property="og:image:secure_url" content={image} />
+            <meta property="og:image:type" content={imageType} />
+            <meta property="og:image:width" content={String(imageWidth)} />
+            <meta property="og:image:height" content={String(imageHeight)} />
+            <meta property="og:image:alt" content={name} />
 
             <meta name="twitter:title" content={name} />
             <meta name="twitter:description" content={description} />

--- a/src/utils/meta.ts
+++ b/src/utils/meta.ts
@@ -4,10 +4,19 @@ export type MetaProps = {
     name: string;
     description: string;
     image?: string;
+    imageType?: string;
+    imageWidth?: number;
+    imageHeight?: number;
 };
 
 const getOgImageUrl = (id?: string) => {
     return id ? `https://storage.yandexcloud.net/gravity-ui-assets/og/${id}.jpg` : undefined;
+};
+
+const LIBRARY_OG_IMAGE_META = {
+    imageType: 'image/jpeg',
+    imageWidth: 1200,
+    imageHeight: 630,
 };
 
 export const getLibraryMeta = (
@@ -19,6 +28,7 @@ export const getLibraryMeta = (
         name: componentTitle ? `${lib.title} – ${componentTitle}` : lib.title,
         description: t(`libraries-info:description_${lib.id}`),
         image: getOgImageUrl(lib.id),
+        ...LIBRARY_OG_IMAGE_META,
     };
 };
 
@@ -45,6 +55,7 @@ export const getComponentMeta = (params: {
         name: `${libTitle} – ${componentTitle}`,
         description: hasTranslation ? description : `${componentTitle} component from ${libTitle}`,
         image: getOgImageUrl(libId),
+        ...LIBRARY_OG_IMAGE_META,
     };
 };
 


### PR DESCRIPTION
## Summary                                                                                                                                               
                                                                                                                                                           
  Fixes missing OG preview in Telegram (and other social parsers) for library pages such as `https://gravity-ui.com/ru/libraries/uikit`.                   
                                                                                                                                                           
  Two independent problems were causing the preview to silently fail:                                                                                      
                                                                                                                                                           
  ### 1. OG images were PNGs served as `image/jpeg`                                                                                                        
                                                        
  `scripts/update-og-images.mjs` used `page.screenshot()` (Playwright's default = PNG bytes) but uploaded them to S3 as `og/<id>.jpg` with `ContentType:   
  image/jpeg`. Every library OG image on the CDN was a PNG masquerading as JPEG — strict OG parsers (Telegram in particular) reject responses where the
  magic bytes don't match the declared MIME type.                                                                                                          
                                                        
  Fix: pass `{type: 'jpeg', quality: 90}` so Playwright emits real JPEG bytes matching the extension and content-type. Re-running the script re-uploaded   
  correctly-encoded ~42 KB JPEGs at 1200×630.
                                                                                                                                                           
  ### 2. Missing image metadata tags                    

  Telegram/Facebook OG parsers often skip previews when they can't cheaply determine image dimensions and type. Added the standard image extension tags to 
  `Meta`:
                                                                                                                                                           
  - `og:image:secure_url`                               
  - `og:image:type`
  - `og:image:width`
  - `og:image:height`                                                                                                                                      
  - `og:image:alt`
                                                                                                                                                           
  `MetaProps` now accepts `imageType`, `imageWidth`, `imageHeight` with defaults matching the default `/index-social.png` (1280×640 PNG). `getLibraryMeta` 
  / `getComponentMeta` in `src/utils/meta.ts` pass 1200×630 `image/jpeg` to match the library OG images produced by the screenshot script.