### PR TITLE
ci: set GH_TOKEN in update-llms workflow

### DIFF
--- a/.github/workflows/update-llms.yml
+++ b/.github/workflows/update-llms.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Generate llms.txt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm run generate-llms
 
@@ -36,4 +38,4 @@ jobs:
           export COMMIT_MESSAGE="docs: update llms.txt"
           git commit -m "$COMMIT_MESSAGE" || true
           git push --set-upstream origin update-llms-txt --force
-          gh pr create --title "$COMMIT_MESSAGE" --body "" -a "dgaponov" -a "imsitnikov" -a "vvtimofeev" 2>/dev/null || true
+          gh pr create --title "$COMMIT_MESSAGE" --body "" -a "dgaponov" -a "imsitnikov" -a "vvtimofeev" || true


### PR DESCRIPTION
`gh pr create` в воркфлоу `Update llms.txt` падал с ошибкой аутентификации, потому что шагу не был передан `GH_TOKEN`. Ошибка глушилась через `2>/dev/null || true`, поэтому ран завершался успешно: ветка `update-llms-txt` пушилась, а PR не создавался.

- добавлен `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` шагу «Generate llms.txt» (как в `update-packages-readme.yml`)
- убрано подавление stderr у `gh pr create`, чтобы подобные ошибки были видны в логе

🤖 Generated with [Claude Code](https://claude.com/claude-code)