### PR TITLE
feat: add context7.json for Context7 library verification

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -13,6 +13,7 @@ module.exports = {
         '/sitemap.xml',
         '/robots.txt',
         '/analytics.txt',
+        '/context7.json',
         '/index-social.png',
     ],
 };

--- a/public/context7.json
+++ b/public/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/llmstxt/gravity-ui_llms_txt",
+  "public_key": "pk_plCsHtYUNB4nnfebz0tJt"
+}


### PR DESCRIPTION
## What

Adds the Context7 ownership verification file, served at https://gravity-ui.com/context7.json:

```json
{
  "url": "https://context7.com/llmstxt/gravity-ui_llms_txt",
  "public_key": "pk_plCsHtYUNB4nnfebz0tJt"
}
```

## Why the config change

The file itself is just `public/context7.json`, but that alone is not enough. The middleware matcher in `src/middleware.ts` only excludes `_next|api|favicon|static|manifest|llms`, so `/context7.json` still goes through locale detection and gets rewritten based on `Accept-Language` / `NEXT_LOCALE`.

Adding `/context7.json` to `routesWithoutRedirect` pins it to the default locale — the same treatment `robots.txt`, `analytics.txt` and `index-social.png` already get.

## Verification

Checked against a local dev server.

Without the `routesWithoutRedirect` entry:

```
Accept-Language: ru-RU,ru;q=0.9  ->  307  ->  /ru/context7.json  ->  404
```

With it, all 9 locales resolve to the file:

| Accept-Language | Result |
|---|---|
| en, ru, es, zh, fr, de, ko, pt, ja | `200 application/json; charset=UTF-8` |

Also confirmed:
- `NEXT_LOCALE=ru` cookie → `200`
- `/ru/context7.json` → `307` → `/context7.json` → `200` (canonicalised rather than 404)
- Response body parses as JSON and matches the expected content exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)