### PR TITLE
fix(themes): mobile light/dark toggle and preview styles on client-side navigation

### DIFF
--- a/src/components/Themes/Themes.scss
+++ b/src/components/Themes/Themes.scss
@@ -214,8 +214,14 @@ $contentMaxWidth: calc(1232px + 16px + 80px);
     // sticky bar's toggle takes over to avoid duplicate controls on screen.
     // The class has to carry the BEM namespace `block()` adds, otherwise the
     // selector matches nothing and both toggles stay on screen together.
-    &__content-wrapper:has(&__sticky-bar_visible) .#{variables.$ns}preview-tab__mode-toggle {
-        display: none;
+    //
+    // Only above `sm`: on phone the sticky bar hides its own toggle (see
+    // `__sticky-mode-toggle` above), so handing over there left no way to
+    // switch light/dark at all once the page was scrolled past the threshold.
+    @media (min-width: #{map-get(pcVariables.$gridBreakpoints, 'sm') + 1}) {
+        &__content-wrapper:has(&__sticky-bar_visible) .#{variables.$ns}preview-tab__mode-toggle {
+            display: none;
+        }
     }
 
     &__header-actions {

--- a/src/components/Themes/Themes.tsx
+++ b/src/components/Themes/Themes.tsx
@@ -13,7 +13,6 @@ import {
 } from '@gravity-ui/uikit';
 import {parseJSON} from '@gravity-ui/uikit-themer';
 import {useTranslation} from 'next-i18next';
-import dynamic from 'next/dynamic';
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {ThemeExport} from 'src/components/Themes/ui/ThemeExport/ThemeExport';
 
@@ -24,6 +23,16 @@ import {CustomScrollbar} from '../CustomScrollbar';
 import {TagItem, Tags} from '../Tags/Tags';
 
 import './Themes.scss';
+// PreviewTab renders heavy UISamples that aren't SSR-safe in the current
+// uikit/navigation stack — one of the descendant components resolves to
+// `undefined` during server render, so it is mounted only after hydration
+// (see `isHydrated` below).
+//
+// It has to be a STATIC import, not `next/dynamic`. With `dynamic(..., {ssr:
+// false})` Next only emits this subtree's CSS as a `<link rel=preload>` on a
+// client-side route transition and never promotes it to a stylesheet, so
+// arriving at /themes from another page left the UI samples (AsideHeader in
+// particular) completely unstyled until a hard reload.
 import type {ThemePreviewMode} from './gallery';
 import {loadThemePayload} from './gallery';
 import {useThemeCreator, useThemeCreatorMethods} from './hooks';
@@ -35,21 +44,13 @@ import {ColorsTab} from './ui/ColorsTab/ColorsTab';
 import {CommunityThemesModal} from './ui/CommunityThemesModal';
 import {GalleryHintPopover} from './ui/GalleryHintPopover/GalleryHintPopover';
 import {PreviewModeToggle} from './ui/PreviewModeToggle/PreviewModeToggle';
+import {PreviewTab} from './ui/PreviewTab/PreviewTab';
 import {SpecificTab} from './ui/SpecificTab/SpecificTab';
 import {ThemeCreatorContextProvider} from './ui/ThemeCreatorContextProvider';
 import {ThemeGalleryDrawer} from './ui/ThemeGalleryDrawer';
 import {ThemeImport} from './ui/ThemeImport/ThemeImport';
 import {ThemePlaygroundBar} from './ui/ThemePlaygroundBar/ThemePlaygroundBar';
 import {TypographyTab} from './ui/TypographyTab/TypographyTab';
-
-// PreviewTab renders heavy UISamples that aren't SSR-safe in the current
-// uikit/navigation stack — one of the descendant components resolves to
-// `undefined` during server render. Load it client-only so Preview can be
-// the default tab without crashing the page.
-const PreviewTab = dynamic(
-    () => import('./ui/PreviewTab/PreviewTab').then((mod) => mod.PreviewTab),
-    {ssr: false},
-);
 
 const b = block('themes');
 
@@ -326,16 +327,23 @@ const ThemesContent = () => {
 
     const [activeTab, setActiveTab] = useState<ThemeTab>(ThemeTab.Preview);
 
+    // PreviewTab's UI samples are not SSR-safe (see the import comment), so the
+    // subtree is skipped on the server pass and mounted once hydration is done.
+    const [isHydrated, setHydrated] = useState(false);
+    useEffect(() => {
+        setHydrated(true);
+    }, []);
+
     const TabComponent = tabToComponent[activeTab];
 
     let tabContent: React.ReactNode = null;
     if (activeTab === ThemeTab.Preview) {
-        tabContent = (
+        tabContent = isHydrated ? (
             <PreviewTab
                 forcedPreviewMode={forcedPreviewMode}
                 onPreviewModeChange={setForcedPreviewMode}
             />
-        );
+        ) : null;
     } else if (TabComponent) {
         tabContent = <TabComponent />;
     }

--- a/src/components/Themes/ui/GalleryHintPopover/GalleryHintPopover.tsx
+++ b/src/components/Themes/ui/GalleryHintPopover/GalleryHintPopover.tsx
@@ -1,8 +1,10 @@
+import {BREAKPOINTS} from '@gravity-ui/page-constructor';
 import type {PopoverInstanceProps} from '@gravity-ui/uikit/legacy';
 import {Popover, PopoverBehavior} from '@gravity-ui/uikit/legacy';
 import {useTranslation} from 'next-i18next';
 import React from 'react';
 
+import {useWindowBreakpoint} from '../../../../hooks/useWindowBreakpoint';
 import {block, getContentScrollElement} from '../../../../utils';
 
 import './GalleryHintPopover.scss';
@@ -17,6 +19,7 @@ interface GalleryHintPopoverProps {
 export const GalleryHintPopover: React.FC<GalleryHintPopoverProps> = ({anchorRef}) => {
     const {t} = useTranslation('themes');
     const popoverRef = React.useRef<PopoverInstanceProps>(null);
+    const isMobile = useWindowBreakpoint() < BREAKPOINTS.sm;
 
     const dismiss = React.useCallback(() => {
         popoverRef.current?.closeTooltip();
@@ -42,6 +45,11 @@ export const GalleryHintPopover: React.FC<GalleryHintPopoverProps> = ({anchorRef
         // user action — scroll, click outside the popover, link click,
         // button press, etc. Scroll listener also covers the visual
         // overlap with the semi-transparent landing nav (blur quirk).
+        //
+        // Not on touch, though: a phone scrolls on the way to the bar, so the
+        // hint vanished before it could be read. There a tap dismisses it,
+        // which is the same "any user action" intent minus the accidental
+        // trigger.
         const scrollContainer = getContentScrollElement();
         const scrollTarget = scrollContainer ?? window;
         const handleScroll = () => {
@@ -59,20 +67,26 @@ export const GalleryHintPopover: React.FC<GalleryHintPopoverProps> = ({anchorRef
             }
             dismiss();
         };
-        scrollTarget.addEventListener('scroll', handleScroll, {once: true, passive: true});
+        if (!isMobile) {
+            scrollTarget.addEventListener('scroll', handleScroll, {once: true, passive: true});
+        }
         document.addEventListener('pointerdown', handlePointerDown, true);
         return () => {
             scrollTarget.removeEventListener('scroll', handleScroll);
             document.removeEventListener('pointerdown', handlePointerDown, true);
         };
-    }, [dismiss]);
+    }, [dismiss, isMobile]);
 
     return (
         <Popover
             ref={popoverRef}
             anchorRef={anchorRef}
             behavior={PopoverBehavior.Immediate}
-            placement="bottom-start"
+            // The hint is anchored to the first swatch. Opening downwards on a
+            // phone drops the bubble straight onto the rest of the swatch row,
+            // so it covered the very colors it is advertising; flip it above
+            // the row there.
+            placement={isMobile ? 'top-start' : 'bottom-start'}
             theme="special"
             hasClose
             onCloseClick={dismiss}

--- a/src/components/Themes/ui/ThemePlaygroundBar/ThemePlaygroundBar.scss
+++ b/src/components/Themes/ui/ThemePlaygroundBar/ThemePlaygroundBar.scss
@@ -56,10 +56,33 @@ $block: '.#{variables.$ns}theme-playground-bar';
         font-weight: 500;
     }
 
+    // The preset row scrolls horizontally at every size instead of dropping
+    // presets that don't fit — on a phone the hidden ones were unreachable.
+    // `flex-shrink: 0` stays off so the row can actually be squeezed into the
+    // available width and produce the overflow it scrolls through.
     &__swatches {
         display: flex;
         align-items: center;
-        flex-shrink: 0;
+        gap: var(--g-spacing-2);
+        min-width: 0;
+        max-width: 100%;
+        overflow-x: auto;
+        overscroll-behavior-x: contain;
+        scrollbar-width: none;
+        // Room for the active swatch's 2px frame, which would otherwise be
+        // clipped by the scroll box.
+        padding-block: 2px;
+
+        &::-webkit-scrollbar {
+            display: none;
+        }
+    }
+
+    // Set from JS when the row actually overflows: fades the trailing edge so
+    // a partly-cut swatch reads as "there is more to scroll", instead of the
+    // row happening to end flush and looking complete.
+    &__swatches_scrollable {
+        mask-image: linear-gradient(to right, #000 calc(100% - 32px), transparent 100%);
     }
 
     &__swatch {
@@ -125,24 +148,11 @@ $block: '.#{variables.$ns}theme-playground-bar';
         }
 
         &__swatches {
-            justify-content: space-between;
             width: 100%;
         }
 
         &__gallery-button {
             width: 100%;
-        }
-    }
-
-    @container (max-width: #{variables.$extraSmallBreakpoint - 1}) {
-        &__swatch:nth-child(n + 6) {
-            display: none;
-        }
-    }
-
-    @container (max-width: 359px) {
-        &__swatch:nth-child(n + 5) {
-            display: none;
         }
     }
 }

--- a/src/components/Themes/ui/ThemePlaygroundBar/ThemePlaygroundBar.tsx
+++ b/src/components/Themes/ui/ThemePlaygroundBar/ThemePlaygroundBar.tsx
@@ -33,6 +33,28 @@ export const ThemePlaygroundBar: React.FC<ThemePlaygroundBarProps> = ({
 }) => {
     const {t} = useTranslation('themes');
     const breakpoint = useWindowBreakpoint();
+    // The preset row scrolls when it can't fit. CSS alone can't tell whether
+    // it currently overflows, so the trailing fade that advertises the scroll
+    // is toggled from a ResizeObserver.
+    const swatchesRef = React.useRef<HTMLDivElement>(null);
+    const [isSwatchRowScrollable, setSwatchRowScrollable] = React.useState(false);
+
+    React.useEffect(() => {
+        const node = swatchesRef.current;
+        if (!node) {
+            return undefined;
+        }
+        const update = () => {
+            setSwatchRowScrollable(node.scrollWidth - node.clientWidth > 1);
+        };
+        update();
+        const observer = new ResizeObserver(update);
+        observer.observe(node);
+        for (const child of Array.from(node.children)) {
+            observer.observe(child);
+        }
+        return () => observer.disconnect();
+    }, []);
     const isDesktop = breakpoint >= BREAKPOINTS.xl;
     const isMobile = breakpoint < BREAKPOINTS.sm;
     // Mobile source ships PNG only — WebP came out larger than the PNG for
@@ -60,7 +82,10 @@ export const ThemePlaygroundBar: React.FC<ThemePlaygroundBarProps> = ({
                     </Text>
                 </div>
                 <div className={b('bottom-row')}>
-                    <div className={b('swatches')}>
+                    <div
+                        ref={swatchesRef}
+                        className={b('swatches', {scrollable: isSwatchRowScrollable})}
+                    >
                         {BRAND_COLORS_PRESETS.map((preset, i) => {
                             const active = i === activePresetIndex;
                             return (


### PR DESCRIPTION
Two follow-up fixes for regressions from #650, both reproduced on production.

### Preview loses its styles when you arrive at /themes from another page

`PreviewTab` was wrapped in `dynamic(..., {ssr: false})`. On a client-side route transition Next emits that subtree's CSS only as `<link rel="preload">` and never promotes it to a stylesheet, so everything the UI samples render — `AsideHeader` in particular — came out unstyled. A hard reload masked it, which is why it looked intermittent.

Reproduced on production Safari: home → click "Themes" → the aside computes `position: static; width: 1248px` and no rule for its CSS-module class exists in any of the 45 attached sheets. After a reload: 50 sheets, rule present, `position: relative`.

Fixed by importing `PreviewTab` statically and mounting it after hydration, so its CSS belongs to the route on both entry paths while the subtree still never renders on the server. Verified on a production build: after the same client-side navigation the aside is `position: relative` and its rules are attached.

Trade-off: `/themes` grows from 78.2 kB to 140 kB (First Load JS 790 kB → 882 kB) because the subtree is no longer code-split. The underlying SSR problem is untouched — making `PreviewTab` SSR-safe would let both the `dynamic` and the hydration gate go away, and is worth doing separately.

### On phones the light/dark toggle disappears once you scroll

The sticky bar hides its own toggle below `sm`, and a `:has()` rule hid the in-section toggle next to the "UI Samples" heading whenever the sticky bar appeared — so past the sticky threshold a phone had no theme toggle at all. The handover rule now applies only above `sm`.

Verified at 390 px: the in-section toggle stays visible after scrolling (sticky bar active). At 1280 px the handover is unchanged — in-section toggle hides, the sticky bar's toggle shows.