### PR TITLE
feat(themes): add analytics events for the theme gallery

### DIFF
--- a/src/components/Themes/Themes.tsx
+++ b/src/components/Themes/Themes.tsx
@@ -18,7 +18,7 @@ import {ThemeExport} from 'src/components/Themes/ui/ThemeExport/ThemeExport';
 
 import {CONTENT_WRAPPER_ID} from '../../constants';
 import {useWindowBreakpoint} from '../../hooks/useWindowBreakpoint';
-import {block, getContentScrollElement} from '../../utils';
+import {block, getContentScrollElement, sendAnalyticsEvent} from '../../utils';
 import {CustomScrollbar} from '../CustomScrollbar';
 import {TagItem, Tags} from '../Tags/Tags';
 
@@ -40,6 +40,7 @@ import {DEFAULT_THEME} from './lib/constants';
 import type {BrandPreset} from './lib/constants';
 import {normalizeImportedTheme} from './lib/normalizeImportedTheme';
 import {BorderRadiusTab} from './ui/BorderRadiusTab/BorderRadiusTab';
+import {parseRgbStringToHex} from './ui/ColorPickerInput/utils';
 import {ColorsTab} from './ui/ColorsTab/ColorsTab';
 import {CommunityThemesModal} from './ui/CommunityThemesModal';
 import {GalleryHintPopover} from './ui/GalleryHintPopover/GalleryHintPopover';
@@ -118,6 +119,7 @@ const ThemesContent = () => {
     // generation also drops a gallery load still in flight so it can't land on
     // top of the freshly imported theme.
     const handleImportSuccess = useCallback(() => {
+        sendAnalyticsEvent('theme_import');
         applyGenerationRef.current += 1;
         setActiveThemeId(null);
         setActivePresetIndex(null);
@@ -149,6 +151,7 @@ const ThemesContent = () => {
             // Invalidate any in-flight theme load so it can't overwrite this preset.
             applyGenerationRef.current += 1;
             applyBrandPreset(preset);
+            sendAnalyticsEvent('theme_preset_select', parseRgbStringToHex(preset.brandColor));
             setActivePresetIndex(index);
             setActiveThemeId(null);
             setForcedPreviewMode(null);
@@ -170,6 +173,7 @@ const ThemesContent = () => {
                 }
                 const gravityTheme = normalizeImportedTheme(parseJSON(payload));
                 importTheme(gravityTheme);
+                sendAnalyticsEvent('theme_apply', id);
                 setActiveThemeId(id);
                 setActivePresetIndex(null);
                 setForcedPreviewMode(mode);
@@ -195,6 +199,7 @@ const ThemesContent = () => {
     );
 
     const handleStartFromScratch = useCallback(() => {
+        sendAnalyticsEvent('theme_start_scratch');
         applyGenerationRef.current += 1;
         setCommunityModalOpen(false);
         importTheme(DEFAULT_THEME);
@@ -243,6 +248,13 @@ const ThemesContent = () => {
     }, [pendingApply, performApplyPreset, performApplyTheme]);
 
     const cancelPendingApply = useCallback(() => setPendingApply(null), []);
+
+    const toggleGalleryDrawer = useCallback(() => {
+        if (!galleryDrawerOpen) {
+            sendAnalyticsEvent('gallery_open');
+        }
+        setGalleryDrawerOpen(!galleryDrawerOpen);
+    }, [galleryDrawerOpen]);
 
     const tags: TagItem<ThemeTab>[] = useMemo(
         () => [
@@ -423,7 +435,7 @@ const ThemesContent = () => {
                     <ThemePlaygroundBar
                         activePresetIndex={activePresetIndex}
                         onSelectPreset={handleSelectPreset}
-                        onOpenGallery={() => setGalleryDrawerOpen((open) => !open)}
+                        onOpenGallery={toggleGalleryDrawer}
                         firstSwatchRef={firstSwatchRef}
                     />
                     <GalleryHintPopover anchorRef={firstSwatchRef} />
@@ -446,6 +458,7 @@ const ThemesContent = () => {
                 activeThemeId={activeThemeId}
                 onApplyTheme={handleApplyTheme}
                 onOpenAllThemes={() => {
+                    sendAnalyticsEvent('gallery_all_open');
                     setGalleryDrawerOpen(false);
                     setCommunityModalOpen(true);
                 }}

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -15,7 +15,13 @@ export type AnalyticsAction =
     | 'start_creating_view'
     | 'prompt_copy'
     | 'howto_start_click'
-    | 'tab_switch';
+    | 'tab_switch'
+    | 'gallery_open'
+    | 'gallery_all_open'
+    | 'theme_apply'
+    | 'theme_preset_select'
+    | 'theme_import'
+    | 'theme_start_scratch';
 
 // Single analytics channel: a `cta` event goes to the dataLayer, where GTM
 // routes it to GA4 (event = cta_action) and Metrika (reachGoal(cta_action)).


### PR DESCRIPTION
## What

Follow-up to #740: instruments the new theme gallery (#650) so we can see which themes people try on and whether the gallery leads to real adoption.

Six events, all through the existing `cta` dataLayer contract — no GTM changes needed:

| Action | Where | Label |
|---|---|---|
| `gallery_open` | "Theme Gallery" button in the playground bar (counted on opening only) | — |
| `theme_apply` | gallery theme applied from a card (drawer or modal), after the payload loads | theme id (`coffee`, `tea`, …) |
| `theme_preset_select` | brand color swatch in the playground bar | hex color |
| `gallery_all_open` | "All gallery themes" modal | — |
| `theme_import` | successful import of a custom theme | — |
| `theme_start_scratch` | "Start from scratch" in the modal | — |

Together with the existing `theme_export` this gives the funnel: `/themes` view → `gallery_open` → `theme_apply` → `theme_export`.

Deliberately not tracked: per-card dark/light toggles, the global preview mode toggle, drawer close, the first-visit hint popover, and the unsaved-changes confirm dialog.

## Wiring

JS goals with the same identifiers are already registered in Metrika counter 94770252. GA4 picks the new event names up automatically via the `cta` trigger; `cta_label` is already a registered custom dimension.

## Testing

Verified end-to-end in headless Chromium against the dev server: every event fires with the expected label (`theme_apply baseline`, `theme_preset_select #0029ff`, `theme_import` with a gallery JSON payload, etc.). `npm run typecheck` and ESLint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)