### PR TITLE
fix(themes): /ru/themes crashes with "Cannot read properties of undefined (reading 'formats')"

### DIFF
--- a/src/components/Themes/Themes.tsx
+++ b/src/components/Themes/Themes.tsx
@@ -1,3 +1,4 @@
+import {settings as dateUtilsSettings} from '@gravity-ui/date-utils';
 import {ArrowUpFromSquare} from '@gravity-ui/icons';
 import {BREAKPOINTS, Grid} from '@gravity-ui/page-constructor';
 import {
@@ -26,7 +27,7 @@ import './Themes.scss';
 // PreviewTab renders heavy UISamples that aren't SSR-safe in the current
 // uikit/navigation stack — one of the descendant components resolves to
 // `undefined` during server render, so it is mounted only after hydration
-// (see `isHydrated` below).
+// (see `isPreviewReady` below).
 //
 // It has to be a STATIC import, not `next/dynamic`. With `dynamic(..., {ssr:
 // false})` Next only emits this subtree's CSS as a `<link rel=preload>` on a
@@ -80,7 +81,7 @@ type PendingApply =
     | {type: 'theme'; id: string; mode: ThemePreviewMode};
 
 const ThemesContent = () => {
-    const {t} = useTranslation('themes');
+    const {t, i18n} = useTranslation('themes');
 
     const breakpoint = useWindowBreakpoint();
     const isMobile = breakpoint < BREAKPOINTS.sm;
@@ -341,16 +342,39 @@ const ThemesContent = () => {
 
     // PreviewTab's UI samples are not SSR-safe (see the import comment), so the
     // subtree is skipped on the server pass and mounted once hydration is done.
-    const [isHydrated, setHydrated] = useState(false);
+    //
+    // Mounting also waits for the dayjs locale of the current language. The
+    // Apartment sample renders a `DatePicker`, and date-components reads
+    // `dayjs.Ls[lang].formats` synchronously in a `useState` initializer. The
+    // landing kicks off `settings.loadLocale()` for every language at startup
+    // but never awaits it, so on a slow connection the sample mounted before
+    // the `ru` locale chunk arrived and the whole /ru/themes page died with
+    // "Cannot read properties of undefined (reading 'formats')". `loadLocale`
+    // is idempotent (`en` is preloaded), so awaiting it is free once the locale
+    // is in. If the locale chunk fails to load, the samples stay unmounted:
+    // an empty Preview tab beats taking the whole page down.
+    const [isPreviewReady, setPreviewReady] = useState(false);
     useEffect(() => {
-        setHydrated(true);
-    }, []);
+        let cancelled = false;
+        setPreviewReady(false);
+        dateUtilsSettings.loadLocale(i18n.language).then(
+            () => {
+                if (!cancelled) {
+                    setPreviewReady(true);
+                }
+            },
+            () => undefined,
+        );
+        return () => {
+            cancelled = true;
+        };
+    }, [i18n.language]);
 
     const TabComponent = tabToComponent[activeTab];
 
     let tabContent: React.ReactNode = null;
     if (activeTab === ThemeTab.Preview) {
-        tabContent = isHydrated ? (
+        tabContent = isPreviewReady ? (
             <PreviewTab
                 forcedPreviewMode={forcedPreviewMode}
                 onPreviewModeChange={setForcedPreviewMode}


### PR DESCRIPTION
Hotfix for a production crash reported from the community chat: `/ru/themes` dies with `TypeError: Cannot read properties of undefined (reading 'formats')` and Next shows "Application error: a client-side exception has occurred". Reproduced on production in Chrome with `NEXT_LOCALE=ru`.

### Cause

The Apartment UI sample renders a `DatePicker` from `@gravity-ui/date-components`, which reads `dayjs.Ls[lang].formats` synchronously inside a `useState` initializer (`x()` in chunk `11694`, `o = i.dayjs.Ls[n].formats`). The landing calls `settings.loadLocale('ru')` at startup in `Layout` but never awaits it, so whenever the sample mounts before the `ru` locale chunk has resolved, `dayjs.Ls.ru` is still `undefined` and the whole page throws.

This surfaced with #650: before it the default tab was `Colors`, so the samples never mounted on page load. Since #746 `PreviewTab` mounts right after hydration, which makes the window even tighter.

### Fix

`PreviewTab` is mounted only after `settings.loadLocale(i18n.language)` resolves. `loadLocale` is idempotent (`en` is preloaded, other locales are cached after the first call), so once the locale is in this costs nothing. If the locale chunk fails to load, the samples stay unmounted — an empty Preview tab beats taking the page down.

### Verified

Production build of this branch, Chrome with `NEXT_LOCALE=ru`, `/ru/themes`: title «Gravity UI – Темы», no error, preview mounted, `DatePicker` rendered, no failed chunk requests. `tsc` and `eslint` clean.