### PR TITLE
fix(slider): resolve rc-slider default export to fix SSR 500

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -69,6 +69,16 @@ module.exports = withBundleAnalyzer({
             use: 'raw-loader',
         });
 
+        // rc-slider resolves to its CJS build (`main: ./lib/index`), which has no `exports`
+        // field. Combined with `esmExternals: 'loose'`, webpack hands uikit's
+        // `import Slider from 'rc-slider'` the module namespace object instead of the default
+        // export, so BaseSlider renders an invalid element type and SSR of
+        // /components/uikit/slider throws. Pointing at the ESM build gives a real default export.
+        config.resolve.alias = {
+            ...config.resolve.alias,
+            'rc-slider$': path.resolve(__dirname, 'node_modules/rc-slider/es/index.js'),
+        };
+
         if (!options.isServer) {
             config.resolve.fallback.fs = false;
         }
@@ -137,6 +147,10 @@ module.exports = withBundleAnalyzer({
         '@gravity-ui/aikit',
         '@gravity-ui/illustrations',
         'swiper',
+        // Bundled (not left as ESM externals) so webpack resolves their extensionless
+        // internal imports — see the `rc-slider$` alias above.
+        'rc-slider',
+        'rc-util',
         '@uiw/react-color',
         '@uiw/react-color-name',
         'colors-named',


### PR DESCRIPTION
`/components/uikit/slider` отдавал 500 во всех локалях — единственный не-200 среди 160 URL sitemap.

`rc-slider` резолвится в CJS-сборку без поля `exports`; вместе с `esmExternals: 'loose'` webpack отдавал uikit объект пространства имён вместо default-экспорта, и SSR падал на `Element type is invalid`. Алиас на ESM-сборку + бандлинг `rc-slider`/`rc-util` (иначе Node не резолвит их внутренние импорты без расширений).

Проверено: 200 с полным контентом в dev и prod, en/ru/es/zh; build, lint, typecheck, e2e — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)