### PR TITLE
fix(components): return 404 for unknown component libraries

### DIFF
--- a/src/pages/components/[libId]/index.tsx
+++ b/src/pages/components/[libId]/index.tsx
@@ -7,8 +7,21 @@ import {libs} from '../../../content/components';
 import {getI18nProps} from '../../../utils';
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
+    const libId = ctx.params?.libId as string;
+
+    // Without this check any /components/<anything> renders an empty shell with HTTP 200,
+    // so unlimited non-existent URLs are indexable as soft 404s. Mirrors the guard in
+    // src/pages/design/[sectionId]/index.tsx.
+    const lib = libs.find((item) => item.id === libId);
+
+    if (!lib) {
+        return {
+            notFound: true,
+        };
+    }
+
     return {
-        props: {libId: ctx.params?.libId, ...(await getI18nProps(ctx))},
+        props: {libId, ...(await getI18nProps(ctx))},
     };
 };
 


### PR DESCRIPTION
`/components/<что угодно>` отдавал 200 с пустой оболочкой — неограниченное число несуществующих URL было индексируемыми soft 404. При этом `/<чушь>` и `/components/uikit/<чушь>` уже корректно отдавали 404.

Добавлена проверка `libId` по `libs` в `getServerSideProps` — ровно та же, что уже есть в `src/pages/design/[sectionId]/index.tsx`.

`/components` и `/components/uikit` намеренно оставлены как есть: эти URL должны ранжироваться, им нужен контент, а не редирект.

Проверено: 404 в en/ru/es, остальные страницы 200, скан всех URL sitemap без новых падений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)