### PR TITLE
feat(security): add security response headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -105,6 +105,37 @@ module.exports = withBundleAnalyzer({
 
         return config;
     },
+    async headers() {
+        return [
+            {
+                source: '/:path*',
+                headers: [
+                    {
+                        key: 'Strict-Transport-Security',
+                        // `preload` is deliberately omitted: submitting to the preload list is
+                        // effectively irreversible. Add it only after confirming every
+                        // subdomain is HTTPS-only and you intend to submit.
+                        value: 'max-age=31536000; includeSubDomains',
+                    },
+                    {key: 'X-Content-Type-Options', value: 'nosniff'},
+                    {
+                        key: 'X-Frame-Options',
+                        // Must stay SAMEORIGIN, not DENY: SandboxBlock embeds
+                        // `${window.location.origin}/sandbox/<libId>/<componentId>` in an iframe
+                        // on every component page, and DENY blocks same-origin framing too.
+                        value: 'SAMEORIGIN',
+                    },
+                    {key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin'},
+                    {
+                        key: 'Permissions-Policy',
+                        value: 'camera=(), microphone=(), geolocation=()',
+                    },
+                ],
+            },
+        ];
+    },
+    // Drops the `X-Powered-By: Next.js` version-disclosure header.
+    poweredByHeader: false,
     reactStrictMode: true,
     // The theme builder route was renamed /themer -> /themes; keep old
     // links and indexed URLs working with a permanent redirect.


### PR DESCRIPTION
Сайт не отдавал ни одного заголовка безопасности и раскрывал фреймворк через `X-Powered-By`. Добавлены HSTS, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy` + `poweredByHeader: false`.

Два отступления от шаблона:
- `X-Frame-Options: SAMEORIGIN`, не `DENY` — `SandboxBlock` встраивает same-origin iframe на каждой странице компонента, `DENY` сломал бы все демо.
- HSTS без `preload` и на год, а не на два: попадание в preload-список необратимо.

⚠️ **Перед мержем:** стоит `includeSubDomains`. Если какой-то поддомен отдаётся по HTTP, он станет недоступен, и браузеры запомнят это на год. Скажите — уберу.

CSP не добавлял, ему нужен отдельный allow-list под `storage.yandexcloud.net` и GTM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)