### PR TITLE
perf(fonts): self-host Inter via next/font instead of remote stylesheets

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -69,6 +69,15 @@ module.exports = withBundleAnalyzer({
             use: 'raw-loader',
         });
 
+        // @gravity-ui/uikit/styles/fonts.css is nothing but a remote Google Fonts @import, and
+        // blog-constructor / page-constructor import it transitively. Inter is self-hosted via
+        // next/font (src/fonts.ts), so stub it out to keep the render-blocking request from
+        // coming back through a dependency.
+        config.resolve.alias = {
+            ...config.resolve.alias,
+            '@gravity-ui/uikit/styles/fonts.css': path.resolve(__dirname, 'src/noop.css'),
+        };
+
         if (!options.isServer) {
             config.resolve.fallback.fs = false;
         }

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -1,0 +1,24 @@
+import {Inter} from 'next/font/google';
+
+/**
+ * Self-hosted via next/font instead of a remote stylesheet.
+ *
+ * Inter used to be pulled in by two CSS `@import url(https://fonts.googleapis.com/...)`
+ * statements — one in vendors.scss and one inside @gravity-ui/uikit/styles/fonts.css.
+ * A CSS @import is only discovered after the importing stylesheet has been downloaded and
+ * parsed, so the critical path was serialized:
+ * document -> app CSS -> fonts.googleapis.com -> fonts.gstatic.com, with a DNS + TLS
+ * handshake for each third-party origin.
+ *
+ * next/font downloads the files at build time and serves them from our own origin with a
+ * preload hint, which removes both extra origins and both extra round trips.
+ */
+// eslint-disable-next-line new-cap -- next/font loaders are capitalised factory functions
+export const inter = Inter({
+    // latin-ext covers accented characters used by the pt/fr/de locales; cyrillic covers ru.
+    // Korean, Japanese and Chinese are not covered by Inter and fall back to system fonts,
+    // exactly as before.
+    subsets: ['latin', 'latin-ext', 'cyrillic'],
+    weight: ['200', '400', '600'],
+    display: 'swap',
+});

--- a/src/noop.css
+++ b/src/noop.css
@@ -1,0 +1,8 @@
+/*
+ * Empty stylesheet used to alias @gravity-ui/uikit/styles/fonts.css.
+ *
+ * That file's entire content is a remote `@import url(https://fonts.googleapis.com/...)`.
+ * blog-constructor and page-constructor pull it in transitively, which re-introduced the
+ * render-blocking third-party font request that src/fonts.ts exists to remove. Inter is now
+ * self-hosted via next/font, so the remote stylesheet is redundant.
+ */

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,12 @@
 import '@diplodoc/transform/dist/css/base.css';
 import '@gravity-ui/blog-constructor/styles/styles.css';
 import '@gravity-ui/markdown-editor/styles/styles.css';
-import '@gravity-ui/uikit/styles/fonts.css';
 import '@gravity-ui/uikit/styles/styles.css';
 import {NextComponentType} from 'next';
 import {appWithTranslation} from 'next-i18next';
 import 'overlayscrollbars/overlayscrollbars.css';
 
+import {inter} from '../fonts';
 import {useAnalyticsOutboundLinks} from '../hooks/useAnalyticsOutboundLinks';
 import {useReportWebVitals} from '../hooks/useReportWebVitals';
 import {WindowBreakpointProvider} from '../hooks/useWindowBreakpoint';
@@ -26,6 +26,11 @@ export const App = ({
 
     return (
         <WindowBreakpointProvider>
+            <style jsx global>{`
+                :root {
+                    --font-inter: ${inter.style.fontFamily};
+                }
+            `}</style>
             <Component {...pageProps} />
         </WindowBreakpointProvider>
     );

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,6 +17,16 @@ body.g-root,
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 
+    // uikit's own default is `"Inter", ...` by name, which used to resolve because a remote
+    // stylesheet loaded Inter globally. Inter is now self-hosted via next/font under a
+    // generated family name, so the default is repointed at the variable here to keep
+    // sandbox pages (excluded from the :not(.sandbox) block below) rendering as before.
+    // Doubled selector: uikit's own .g-root rule has equal specificity and wins on source
+    // order, which left sandbox pages with an unresolvable literal "Inter".
+    &#{&} {
+        --g-font-family-sans: var(--font-inter), 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+    }
+
     &__global-loader {
         position: fixed;
         top: 0;
@@ -31,7 +41,7 @@ body.g-root,
     }
 
     &:not(.sandbox) {
-        --g-font-family-sans: 'Inter', 'Helvetica Neue', 'Arial', 'Helvetica', sans-serif;
+        --g-font-family-sans: var(--font-inter), 'Helvetica Neue', 'Arial', 'Helvetica', sans-serif;
         // --g-text-body-font-family: var(--g-font-family-sans);
         --g-text-accent-font-weight: 600;
 

--- a/src/vendors.scss
+++ b/src/vendors.scss
@@ -23,5 +23,4 @@
 @import 'swiper/css/scrollbar';
 
 @import '~@gravity-ui/page-constructor/styles/styles.scss';
-@import 'https://fonts.googleapis.com/css2?family=Inter:wght@200&display=swap';
 @import './github-markdown-dark.css';


### PR DESCRIPTION
Inter подключался через CSS `@import url(https://fonts.googleapis.com/...)`. Такой импорт обнаруживается только после парсинга импортирующего стиля, поэтому цепочка была последовательной: документ → CSS → googleapis → gstatic, с DNS и TLS на каждый сторонний домен (~0.9–1.2 с блокировки на мобильном).

Источников было три, а не один: `vendors.scss`, прямой импорт `uikit/styles/fonts.css` в `_app` и он же транзитивно через `blog-constructor`. Последний заглушён алиасом, иначе возвращается через зависимость.

Стало: 0 сторонних доменов, шрифты грузятся до стилей по preload. Бонусом next/font даёт size-adjusted fallback, уменьшающий сдвиг макета.

Две детали: шрифт нужно объявлять в `_app`, а не `_document` (иначе CSS не эмитится и Inter молча пропадает), и override `.g-root` использует удвоенный селектор — правило uikit имеет ту же специфичность и выигрывает по порядку.

Это только половина находки про render-blocking. Глобальный CSS-чанк на 522 КБ не тронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)