### PR TITLE
perf(playground): stop bundling monaco-editor alongside the CDN copy

### DIFF
--- a/src/components/ChartsPlayground/Playground/Editor.tsx
+++ b/src/components/ChartsPlayground/Playground/Editor.tsx
@@ -1,7 +1,10 @@
 import {ChartData} from '@gravity-ui/charts';
 import {Button, Flex, Hotkey, Text} from '@gravity-ui/uikit';
 import {Editor as MonacoEditor, OnMount} from '@monaco-editor/react';
-import {KeyCode, KeyMod, type editor} from 'monaco-editor';
+// Type-only: importing values from `monaco-editor` would bundle the whole package, which
+// @monaco-editor/react already loads separately at runtime. Key codes come from the
+// monaco instance handed to onMount instead.
+import type {editor} from 'monaco-editor';
 import {useTranslation} from 'next-i18next';
 import React, {FC, useCallback, useRef, useState} from 'react';
 
@@ -67,12 +70,12 @@ export const Editor: FC<Props> = ({data, onApplyChanges, onReset}) => {
         [],
     );
 
-    const handleMount = useCallback(
-        (editor: editor.IStandaloneCodeEditor) => {
+    const handleMount = useCallback<OnMount>(
+        (editor, monaco) => {
             editorRef.current = editor;
             editor.setValue(JSON.stringify(data, null, 2));
             // eslint-disable-next-line no-bitwise
-            editor.addCommand(KeyMod.CtrlCmd | KeyCode.Enter, handleApplyChanges);
+            editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, handleApplyChanges);
         },
         [data],
     );

--- a/src/components/GraphPlayground/Playground/Editor/index.tsx
+++ b/src/components/GraphPlayground/Playground/Editor/index.tsx
@@ -1,7 +1,6 @@
 import {TBlock, TBlockId, TConnection} from '@gravity-ui/graph';
 import {Button, Flex, Hotkey, Text} from '@gravity-ui/uikit';
 import {Editor, OnMount, OnValidate, loader} from '@monaco-editor/react';
-import {KeyCode, KeyMod} from 'monaco-editor/esm/vs/editor/editor.api';
 import {Ref, forwardRef, useCallback, useImperativeHandle, useRef, useState} from 'react';
 
 import {block} from '../../../../utils';
@@ -117,11 +116,17 @@ export const ConfigEditor = forwardRef(function ConfigEditor(
         <Flex direction="column" className={b()}>
             <Flex grow={1}>
                 <Editor
-                    onMount={(editor) => {
+                    onMount={(editor, monaco) => {
                         monacoRef.current = editor;
                         monacoRef.current?.setValue(JSON.stringify(valueRef.current, null, 2));
-                        // eslint-disable-next-line no-bitwise
-                        editor.addCommand(KeyMod.CtrlCmd | KeyCode.Enter, applyChanges);
+                        // Key codes come from the monaco instance rather than a static import
+                        // of `monaco-editor`, which would bundle the whole package alongside
+                        // the copy @monaco-editor/react already loads at runtime.
+                        editor.addCommand(
+                            // eslint-disable-next-line no-bitwise
+                            monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+                            applyChanges,
+                        );
                     }}
                     onValidate={(markers) => {
                         setErrorMarker(markers.filter((m) => m.severity === 8)[0] || null);


### PR DESCRIPTION
Оба редактора плейграундов импортировали значения из пакета `monaco-editor` ради двух констант `KeyCode`/`KeyMod` в одной строке. Импорт значения затягивает весь пакет в бандл, а `@monaco-editor/react` и так качает Monaco с jsDelivr — то есть за редактор платили дважды.

Коды клавиш теперь берутся из инстанса `monaco`, который `onMount` передаёт вторым аргументом, остальное стало `import type`.

`/libraries/charts/playground`, прод-сборка, чистый профиль: свой JS **2094 → 1347 КБ** (−36%), всего **3054 → 2307 КБ**. CDN-часть не изменилась — это настоящий редактор. Исчезли чанки на 2.0 МБ и 216 КБ; "First Load JS" не изменился, потому что они асинхронные.

Обёртка в `next/dynamic` уже была на месте — дублирующая копия в бандле и была реальной потерей.

Не проверял вручную, что Cmd/Ctrl+Enter применяет изменения: редактор монтируется без ошибок, но нажатие не эмулировал.

🤖 Generated with [Claude Code](https://claude.com/claude-code)